### PR TITLE
Use managed API for steam.exe path.

### DIFF
--- a/steamboat/steamboat/components/Steam.cs
+++ b/steamboat/steamboat/components/Steam.cs
@@ -32,7 +32,8 @@ namespace steamboat
 		{
 			if (IsRunning())
 			{
-				SteamPath = steamProc.GetMainModuleFileName();
+                // SteamPath = steamProc.GetMainModuleFileName();
+                SteamPath = steamProc.MainModule.FileName;
 				Properties.Settings.Default["SteamPath"] = SteamPath;
 				Properties.Settings.Default.Save();
 			}


### PR DESCRIPTION
`Process.MainModule.FileName` returns the same as `QueryFullProcessImageNameA`.

Since Steam client is 32-bit, `Win32Exception` will not be thrown when attempting to do so.

*For some reason the indentation looks all good in Visual Studio but messes up in the commit.*